### PR TITLE
Avoid duplicating current NarrationBeat in prompt and add unit test

### DIFF
--- a/src/JohnnyLike.Narration/TraceBeatExtractor.cs
+++ b/src/JohnnyLike.Narration/TraceBeatExtractor.cs
@@ -97,13 +97,16 @@ public sealed class TraceBeatExtractor
             Success: null,
             StatsAfter: null);
 
-        AddBeat(beat);
-
         _beatsSinceLastSummary++;
         bool wantSummary = _beatsSinceLastSummary >= _summaryRefreshEveryN;
         if (wantSummary) _beatsSinceLastSummary = 0;
 
         var prompt = _promptBuilder.BuildNarrationBeatPrompt(beat, text, _facts, _recentBeats, wantSummary);
+
+        // Add the beat after building the prompt so the current beat appears only once
+        // (in the dedicated "## Domain Beat" section) instead of being duplicated in
+        // both that section and "## Domain beats" recent history.
+        AddBeat(beat);
 
         return new NarrationJob(
             JobId: Guid.NewGuid(),

--- a/tests/JohnnyLike.Narration.Tests/TraceBeatExtractorTests.cs
+++ b/tests/JohnnyLike.Narration.Tests/TraceBeatExtractorTests.cs
@@ -339,6 +339,22 @@ public class TraceBeatExtractorTests
     }
 
     [Fact]
+    public void Consume_NarrationBeat_PromptDoesNotDuplicateCurrentBeatInRecentDomainBeats()
+    {
+        var extractor = MakeExtractor();
+
+        // Seed recent history with one prior domain beat.
+        extractor.Consume(MakeNarrationBeat(1.0, "The tide turns.", subjectId: "beach:tide"));
+
+        // Current beat should appear exactly once in the generated prompt.
+        var currentText = "The campfire has gone out.";
+        var job = extractor.Consume(MakeNarrationBeat(2.0, currentText, subjectId: "item:campfire"));
+
+        Assert.NotNull(job);
+        Assert.Equal(1, job!.Prompt.Split(currentText).Length - 1);
+    }
+
+    [Fact]
     public void Consume_NarrationBeat_RequiresNoRegistration()
     {
         // Verifies that NarrationBeat events are handled without any domain-specific handler registration


### PR DESCRIPTION
### Motivation
- Prevent the current `NarrationBeat` from appearing twice in the generated prompt by ensuring it is not included in the "recent beats" history used to build the prompt. 
- Add a regression test to lock in the intended prompt behavior so future changes don't reintroduce the duplication.

### Description
- Move the `AddBeat(beat)` call to after the call to `_promptBuilder.BuildNarrationBeatPrompt(...)` so the built prompt does not include the current beat in the recent-history section. 
- Remove the original earlier `AddBeat(beat)` placement and add a clarifying comment explaining why the beat is added after prompt construction. 
- Add the test `Consume_NarrationBeat_PromptDoesNotDuplicateCurrentBeatInRecentDomainBeats` in `TraceBeatExtractorTests` to assert the current beat appears exactly once in the generated prompt.

### Testing
- Ran unit tests with `dotnet test` for the narration test project, including the new test in `TraceBeatExtractorTests`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e146987c832cb77bdc46e0778c9c)